### PR TITLE
Fix iOS scale issue

### DIFF
--- a/ios/RNMediaManipulator.m
+++ b/ios/RNMediaManipulator.m
@@ -26,7 +26,7 @@ RCT_EXPORT_METHOD(mergeImages:(NSDictionary *)backgroundObj imageObjs:(NSArray *
     backgroundHeight = [NSNumber numberWithDouble:backgroundImage.size.height];
     CGSize backgroundSize = CGSizeMake(backgroundWidth.floatValue, backgroundHeight.floatValue);
     
-    UIGraphicsBeginImageContextWithOptions(backgroundSize, true, 0.0);
+    UIGraphicsBeginImageContextWithOptions(backgroundSize, true, 1.0);
     
     [backgroundImage drawInRect:CGRectMake(0, 0, backgroundWidth.floatValue, backgroundHeight.floatValue)];
 


### PR DESCRIPTION
Hi there, this module is really useful, thanks so much for putting it together! I discovered an issue on iOS where my final image was being saved at 2x scale. After wasting a bunch of time checking size properties along the execution path I found [this Stack Overflow answer](https://stackoverflow.com/questions/42767476/swift-uiimage-has-twice-the-size) which did the trick.